### PR TITLE
fix: pin liteLLM upper bound to 1.82.6 to mitigate supply chain attack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "absl-py",
-    "litellm",
+    "litellm<=1.82.6",
     "pandas",
     "plotly",
     "kaleido",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     py_modules=["anthro_eval_cli"],
     install_requires=[
         "absl-py",
-        "litellm",
+        "litellm<=1.82.6",
         "pandas",
         "plotly",
         "kaleido",


### PR DESCRIPTION
## Summary

liteLLM versions **1.82.7** and **1.82.8** were compromised by the **TeamPCP** group via a supply chain attack through Trivy. The current dependency constraint allows these malicious versions to be installed.

## Impact

The compromised versions steal sensitive credentials including SSH keys, AWS/GCP/K8s credentials, CI/CD tokens, and environment variables. Version 1.82.8 installs a `.pth` persistence mechanism that executes on every Python startup — even after liteLLM is uninstalled.

## Fix

This PR pins the upper bound of the liteLLM dependency to `<=1.82.6`, which is the last known safe version before the compromise. Once BerriAI publishes a verified clean release, this upper bound can be raised.

## References

- [BerriAI/litellm#24512](https://github.com/BerriAI/litellm/issues/24512) — Incident report
- [Wiz.io Analysis](https://www.wiz.io/blog/threes-a-crowd-teampcp-trojanizes-litellm-in-continuation-of-campaign) — Attack chain analysis
- [OSV: MAL-2026-2144](https://osv.dev/vulnerability/MAL-2026-2144) — Advisory